### PR TITLE
Update university branding to 영지국제대학교 and GTCC

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>인천과학대학교 | 미래를 밝히는 스마트 캠퍼스</title>
+    <title>영지국제대학교 | 미래를 밝히는 스마트 캠퍼스</title>
     <meta
       name="description"
-      content="인천과학대학교 공식 홈페이지 - 미래산업을 선도하는 스마트 융합 인재 양성 대학"
+      content="영지국제대학교 공식 홈페이지 - 미래산업을 선도하는 스마트 융합 인재 양성 대학"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700;900&display=swap"
@@ -22,7 +22,7 @@
         <div class="top-bar">
           <div class="container">
             <span>입학상담 032-123-4567</span>
-            <span>대표이메일 admissions@iscu.ac.kr</span>
+            <span>대표이메일 admissions@GTCC.ac.kr</span>
             <div class="d-none d-md-flex gap-3">
               <a href="#">재학생 포털</a>
               <a href="#">원격수업지원센터</a>
@@ -32,8 +32,8 @@
         </div>
         <div class="container nav-wrapper">
           <a class="brand" href="#top">
-            <img src="assets/images/gtcc-logo-trans.png" alt="인천과학대학교 로고" />
-            인천과학대학교
+            <img src="assets/images/gtcc-logo-trans.png" alt="영지국제대학교 로고" />
+            영지국제대학교
           </a>
           <nav class="primary-nav" id="primaryNav">
             <a href="#about">대학소개</a>
@@ -57,9 +57,9 @@
           <div class="container hero-inner">
             <div class="hero-copy">
               <span class="eyebrow"><i class="fas fa-star"></i>INNOVATIVE COLLEGE</span>
-              <h1>미래를 설계하는 인천과학대학교</h1>
+              <h1>미래를 설계하는 영지국제대학교</h1>
               <p>
-                인천과학대학교는 첨단 산업 수요에 맞춘 융합 교육과 스마트 캠퍼스를
+                영지국제대학교는 첨단 산업 수요에 맞춘 융합 교육과 스마트 캠퍼스를
                 통해 지역사회와 세계를 이끌어갈 혁신 인재를 양성합니다. 학생과 교직원이
                 함께 성장하는 미래지향적 교육 환경을 만나보세요.
               </p>
@@ -88,10 +88,10 @@
         <section class="quick-links" id="about">
           <div class="container">
             <div class="section-header">
-              <span>About ISCU</span>
+              <span>About GTCC</span>
               <h2>미래를 향한 교육 혁신</h2>
               <p>
-                인천과학대학교는 전문 인재 양성을 위해 스마트 학습 환경, 맞춤형 학생
+                영지국제대학교는 전문 인재 양성을 위해 스마트 학습 환경, 맞춤형 학생
                 지원, 산업체와의 긴밀한 협력을 기반으로 새로운 대학 모델을 제시합니다.
               </p>
             </div>
@@ -156,7 +156,7 @@
               <span>News & Events</span>
               <h2>캠퍼스 소식과 행사</h2>
               <p>
-                인천과학대학교의 최신 공지와 풍성한 캠퍼스 이벤트를 통해 대학의 현재와
+                영지국제대학교의 최신 공지와 풍성한 캠퍼스 이벤트를 통해 대학의 현재와
                 미래를 생생하게 만나보세요.
               </p>
             </div>
@@ -265,7 +265,7 @@
               <span>Campus Life</span>
               <h2>함께 성장하는 캠퍼스</h2>
               <p>
-                스마트 러닝 허브, 글로벌 교류, 지역사회 봉사 등 ISCU 캠퍼스에서 경험할 수 있는
+                스마트 러닝 허브, 글로벌 교류, 지역사회 봉사 등 GTCC 캠퍼스에서 경험할 수 있는
                 다채로운 활동을 확인하세요.
               </p>
             </div>
@@ -300,9 +300,9 @@
 
         <div class="container">
           <section class="cta">
-            <h2>ISCU와 함께 미래를 디자인하세요</h2>
+            <h2>GTCC와 함께 미래를 디자인하세요</h2>
             <p>
-              인천과학대학교는 학생의 잠재력을 확장시키는 혁신적 교육과 탄탄한 산학 네트워크를
+              영지국제대학교는 학생의 잠재력을 확장시키는 혁신적 교육과 탄탄한 산학 네트워크를
               기반으로, 졸업 이후까지 이어지는 커리어 지원을 제공합니다. 지금 바로 상담을 신청해
               더 큰 가능성을 확인해 보세요.
             </p>
@@ -315,11 +315,11 @@
         <div class="container">
           <div class="footer-grid">
             <div>
-              <h4>인천과학대학교</h4>
+              <h4>영지국제대학교</h4>
               <p>
                 21987 인천광역시 연수구 미래로 123<br />
                 TEL 032-123-4567 · FAX 032-987-6543<br />
-                E-mail admissions@iscu.ac.kr
+                E-mail admissions@GTCC.ac.kr
               </p>
               <div class="social">
                 <a href="#" aria-label="페이스북"><i class="fab fa-facebook-f"></i></a>


### PR DESCRIPTION
## Summary
- replace site references to 인천과학대학교 with 영지국제대학교
- update contact details and section labels from iscu/ISCU to GTCC branding

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dcef6e1c248332ac5f8517ae19deec