### PR TITLE
Create dedicated section pages and reorder navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>대학소개 | 영지국제대학교</title>
+    <meta
+      name="description"
+      content="영지국제대학교 소개 - 대학 비전, 교육철학, 역사, 조직구성 안내"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700;900&display=swap"
+      rel="stylesheet"
+    />
+    <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/fontawesome.css" />
+    <link rel="stylesheet" href="assets/css/custom-style.css" />
+  </head>
+  <body>
+    <div class="page-wrapper">
+      <header class="site-header">
+        <div class="top-bar">
+          <div class="container">
+            <span>입학상담 032-123-4567</span>
+            <span>대표이메일 admissions@GTCC.ac.kr</span>
+            <div class="d-none d-md-flex gap-3">
+              <a href="#">재학생 포털</a>
+              <a href="#">원격수업지원센터</a>
+              <a href="#">글로벌캠퍼스</a>
+            </div>
+          </div>
+        </div>
+        <div class="container nav-wrapper">
+          <a class="brand" href="index.html">
+            <img src="assets/images/gtcc-logo-trans.png" alt="영지국제대학교 로고" />
+            영지국제대학교
+          </a>
+          <nav class="primary-nav" id="primaryNav">
+            <a href="about.html" class="active" aria-current="page">대학소개</a>
+            <a href="news-events.html">소식·행사</a>
+            <a href="departments.html">학과안내</a>
+            <a href="admissions.html">입학안내</a>
+            <a href="campus-life.html">캠퍼스라이프</a>
+          </nav>
+          <div class="nav-actions">
+            <a class="btn-pill outline" href="campus-life.html">캠퍼스맵</a>
+            <a class="btn-pill primary" href="admissions.html">입학원서</a>
+          </div>
+          <button class="nav-toggle" id="navToggle" aria-label="메뉴 열기">
+            <span></span>
+          </button>
+        </div>
+      </header>
+
+      <main>
+        <section class="hero hero--sub">
+          <div class="container hero-inner">
+            <div class="hero-copy">
+              <span class="eyebrow">About GTCC</span>
+              <h1>미래를 밝히는 스마트 융합 대학</h1>
+              <p>
+                영지국제대학교는 산업과 지역사회의 변화를 선도하는 교육 혁신 플랫폼입니다.
+                학생, 교수, 지역이 함께 성장하는 개방형 캠퍼스를 통해 미래 인재를 양성합니다.
+              </p>
+              <div class="hero-meta">
+                <span>#스마트러닝</span>
+                <span>#지역상생</span>
+                <span>#글로벌혁신</span>
+              </div>
+            </div>
+            <div class="hero-visual">
+              <div class="hero-card">
+                <h3>GTCC 비전 2030</h3>
+                <p>
+                  교육 혁신, 산학 동반 성장, 글로벌 네트워크 확장을 통한 미래 융합 대학으로의 도약을 선언합니다.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="quick-links">
+          <div class="container">
+            <div class="section-header">
+              <span>Vision &amp; Mission</span>
+              <h2>GTCC 교육철학</h2>
+              <p>
+                학생의 잠재력과 산업의 요구를 연결하는 맞춤형 교육, 사회적 책임을 실천하는 지속가능 경영을 지향합니다.
+              </p>
+            </div>
+            <div class="quick-card-grid">
+              <article class="quick-card">
+                <i class="fas fa-lightbulb" aria-hidden="true"></i>
+                <h3>창의융합 인재 양성</h3>
+                <p>
+                  AI·데이터 기반 학습과 프로젝트형 수업을 통해 새로운 가치를 창출하는 문제해결형 인재를 배출합니다.
+                </p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-building" aria-hidden="true"></i>
+                <h3>산학협력 생태계</h3>
+                <p>
+                  80여 개 지역 기업과의 파트너십으로 실전형 캡스톤과 현장실습을 강화합니다.
+                </p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-users" aria-hidden="true"></i>
+                <h3>학생 중심 지원</h3>
+                <p>
+                  맞춤형 멘토링, 심리·진로 상담, 글로벌 교류 프로그램으로 학생의 전인적 성장을 지원합니다.
+                </p>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section class="programs">
+          <div class="container">
+              <div class="section-header">
+                <span>History</span>
+                <h2>영지국제대학교 연혁</h2>
+                <p>
+                  개교 이후 혁신과 도전을 이어 온 GTCC의 발자취를 통해 대학의 성장 스토리를 확인하세요.
+                </p>
+              </div>
+            <div class="timeline">
+              <div class="timeline-item">
+                <h3>2024</h3>
+                <p>스마트팩토리 혁신센터 개소 및 XR 기반 실습관 오픈</p>
+              </div>
+              <div class="timeline-item">
+                <h3>2021</h3>
+                <p>AI 융합학부 신설, 지역혁신 플랫폼 사업 선정</p>
+              </div>
+              <div class="timeline-item">
+                <h3>2017</h3>
+                <p>바이오헬스케어 연구단 설립, 글로벌 교류 프로그램 확대</p>
+              </div>
+              <div class="timeline-item">
+                <h3>2010</h3>
+                <p>영지국제대학교로 교명 변경, 캠퍼스 스마트화 착수</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="quick-links">
+          <div class="container">
+            <div class="section-header">
+              <span>Leadership</span>
+              <h2>조직과 리더십</h2>
+              <p>
+                대학의 비전을 실현하는 핵심 조직과 리더진을 소개합니다.
+              </p>
+            </div>
+            <div class="quick-card-grid">
+              <article class="quick-card">
+                <i class="fas fa-chalkboard-teacher" aria-hidden="true"></i>
+                <h3>총장단 메시지</h3>
+                <p>
+                  "미래를 앞서 준비하는 대학"이라는 목표 아래 학생과 지역이 함께 성장하는 혁신 캠퍼스를 구축합니다.
+                </p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-sitemap" aria-hidden="true"></i>
+                <h3>대학 조직도</h3>
+                <p>
+                  교무처, 산학협력단, 학생성장센터, 국제교류원 등 기능별 핵심 조직이 긴밀히 협력합니다.
+                </p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-handshake" aria-hidden="true"></i>
+                <h3>자문위원회</h3>
+                <p>
+                  산업 전문가와 동문 리더로 구성된 자문위원회가 교육과 연구 방향을 제시합니다.
+                </p>
+              </article>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="container">
+          <div class="footer-grid">
+            <div>
+              <h4>영지국제대학교</h4>
+              <p>
+                21987 인천광역시 연수구 미래로 123<br />
+                TEL 032-123-4567 · FAX 032-987-6543<br />
+                E-mail admissions@GTCC.ac.kr
+              </p>
+              <div class="social">
+                <a href="#" aria-label="페이스북"><i class="fab fa-facebook-f"></i></a>
+                <a href="#" aria-label="인스타그램"><i class="fab fa-instagram"></i></a>
+                <a href="#" aria-label="유튜브"><i class="fab fa-youtube"></i></a>
+              </div>
+            </div>
+            <div>
+              <h4>바로가기</h4>
+              <ul>
+                <li><a href="admissions.html">입학안내</a></li>
+                <li><a href="departments.html">학과·전공</a></li>
+                <li><a href="campus-life.html">캠퍼스라이프</a></li>
+              </ul>
+            </div>
+            <div>
+              <h4>학사 정보</h4>
+              <ul>
+                <li><a href="#">학사일정</a></li>
+                <li><a href="#">장학·복지</a></li>
+                <li><a href="#">국제교류</a></li>
+                <li><a href="#">취·창업 지원</a></li>
+              </ul>
+            </div>
+            <div>
+              <h4>고객 지원</h4>
+              <ul>
+                <li><a href="news-events.html">공지사항</a></li>
+                <li><a href="#">증명서 발급</a></li>
+                <li><a href="contact-us.html">문의하기</a></li>
+                <li><a href="#">개인정보처리방침</a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="footer-bottom">
+            ⓒ 2024 Incheon Science College. All rights reserved.
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <script>
+      const navToggle = document.getElementById('navToggle');
+      const primaryNav = document.getElementById('primaryNav');
+
+      navToggle.addEventListener('click', () => {
+        const isOpen = navToggle.classList.toggle('active');
+        primaryNav.classList.toggle('open', isOpen);
+        navToggle.setAttribute('aria-expanded', isOpen);
+      });
+    </script>
+  </body>
+</html>

--- a/admissions.html
+++ b/admissions.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>입학안내 | 영지국제대학교</title>
+    <meta
+      name="description"
+      content="영지국제대학교 입학 전형, 모집일정, 장학금, 지원 절차 안내"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700;900&display=swap"
+      rel="stylesheet"
+    />
+    <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/fontawesome.css" />
+    <link rel="stylesheet" href="assets/css/custom-style.css" />
+  </head>
+  <body>
+    <div class="page-wrapper">
+      <header class="site-header">
+        <div class="top-bar">
+          <div class="container">
+            <span>입학상담 032-123-4567</span>
+            <span>대표이메일 admissions@GTCC.ac.kr</span>
+            <div class="d-none d-md-flex gap-3">
+              <a href="#">재학생 포털</a>
+              <a href="#">원격수업지원센터</a>
+              <a href="#">글로벌캠퍼스</a>
+            </div>
+          </div>
+        </div>
+        <div class="container nav-wrapper">
+          <a class="brand" href="index.html">
+            <img src="assets/images/gtcc-logo-trans.png" alt="영지국제대학교 로고" />
+            영지국제대학교
+          </a>
+          <nav class="primary-nav" id="primaryNav">
+            <a href="about.html">대학소개</a>
+            <a href="news-events.html">소식·행사</a>
+            <a href="departments.html">학과안내</a>
+            <a href="admissions.html" class="active" aria-current="page">입학안내</a>
+            <a href="campus-life.html">캠퍼스라이프</a>
+          </nav>
+          <div class="nav-actions">
+            <a class="btn-pill outline" href="campus-life.html">캠퍼스맵</a>
+            <a class="btn-pill primary" href="#apply">입학원서</a>
+          </div>
+          <button class="nav-toggle" id="navToggle" aria-label="메뉴 열기">
+            <span></span>
+          </button>
+        </div>
+      </header>
+
+      <main>
+        <section class="hero hero--sub">
+          <div class="container hero-inner">
+            <div class="hero-copy">
+              <span class="eyebrow">Admissions</span>
+              <h1>2025학년도 신입생 모집안내</h1>
+              <p>
+                영지국제대학교는 역량 기반 전형과 다양한 장학 제도로 꿈을 설계하는 학생을 기다립니다. 단계별 지원 절차를 확인하고 준비하세요.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="stats-band">
+          <div class="container">
+            <div class="stats-grid">
+              <div class="stat">
+                <h3>07.01</h3>
+                <span>수시모집 원서 접수 시작</span>
+              </div>
+              <div class="stat">
+                <h3>07.20</h3>
+                <span>서류제출 마감</span>
+              </div>
+              <div class="stat">
+                <h3>08.05</h3>
+                <span>면접/실기 일정</span>
+              </div>
+              <div class="stat">
+                <h3>08.20</h3>
+                <span>최종 합격자 발표</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="quick-links">
+          <div class="container">
+            <div class="section-header">
+              <span>Application Guide</span>
+              <h2>전형유형 안내</h2>
+              <p>학생의 성장 스토리를 반영하는 다양한 전형을 운영합니다.</p>
+            </div>
+            <div class="quick-card-grid">
+              <article class="quick-card">
+                <i class="fas fa-user-check" aria-hidden="true"></i>
+                <h3>학생부 종합전형</h3>
+                <p>교과 및 비교과 활동을 종합 평가하고, 전공적합성을 중심으로 심층 면접을 진행합니다.</p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-microscope" aria-hidden="true"></i>
+                <h3>특성화 전형</h3>
+                <p>산업체 경력, 마이스터고, 전문교과 성취도를 반영하여 실무형 인재를 선발합니다.</p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-globe" aria-hidden="true"></i>
+                <h3>글로벌 인재전형</h3>
+                <p>어학 역량과 국제경험을 기반으로 글로벌 프로젝트 수행 계획을 평가합니다.</p>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section class="programs" id="apply">
+          <div class="container">
+            <div class="section-header">
+              <span>How to Apply</span>
+              <h2>지원 절차</h2>
+              <p>온라인 접수부터 최종 등록까지 단계별 안내를 확인하세요.</p>
+            </div>
+            <div class="program-grid">
+              <article class="program-card">
+                <div class="content">
+                  <h3>1. 원서 접수</h3>
+                  <p>입학지원 포털에서 기본정보 입력 후 전형별 자기소개서, 포트폴리오를 제출합니다.</p>
+                </div>
+              </article>
+              <article class="program-card">
+                <div class="content">
+                  <h3>2. 서류 심사</h3>
+                  <p>학생부, 활동보고서, 추천서 등을 바탕으로 전공적합성과 성장가능성을 평가합니다.</p>
+                </div>
+              </article>
+              <article class="program-card">
+                <div class="content">
+                  <h3>3. 면접 &amp; 실기</h3>
+                  <p>전공별 면접과 실기고사를 통해 학업 역량과 문제해결 능력을 검증합니다.</p>
+                </div>
+              </article>
+              <article class="program-card">
+                <div class="content">
+                  <h3>4. 합격자 발표</h3>
+                  <p>입학 포털과 SMS를 통해 합격 여부를 안내하며, 합격자는 등록금 고지서를 확인합니다.</p>
+                </div>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section class="quick-links">
+          <div class="container">
+            <div class="section-header">
+              <span>Scholarships</span>
+              <h2>장학 제도</h2>
+              <p>다양한 장학금으로 학업과 성장을 지원합니다.</p>
+            </div>
+            <div class="quick-card-grid">
+              <article class="quick-card">
+                <i class="fas fa-crown" aria-hidden="true"></i>
+                <h3>미래리더 장학</h3>
+                <p>수시 합격생 중 우수 성적자를 대상으로 등록금 전액과 해외연수를 지원합니다.</p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-hands-helping" aria-hidden="true"></i>
+                <h3>지역상생 장학</h3>
+                <p>지역 고교 출신 학생에게 등록금 감면과 지역기업 멘토링을 제공합니다.</p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-laptop-code" aria-hidden="true"></i>
+                <h3>디지털 인재 장학</h3>
+                <p>AI·SW 분야 공모전 수상자에게 프로젝트 지원비와 맞춤형 연구실 배정을 지원합니다.</p>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section class="cta">
+          <div class="container">
+            <h2>입학상담이 필요하신가요?</h2>
+            <p>입학사정관과의 1:1 상담을 예약하고 전형별 맞춤 전략을 수립하세요.</p>
+            <a class="btn-pill primary" href="contact-us.html">상담 신청</a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="container">
+          <div class="footer-grid">
+            <div>
+              <h4>영지국제대학교</h4>
+              <p>
+                21987 인천광역시 연수구 미래로 123<br />
+                TEL 032-123-4567 · FAX 032-987-6543<br />
+                E-mail admissions@GTCC.ac.kr
+              </p>
+              <div class="social">
+                <a href="#" aria-label="페이스북"><i class="fab fa-facebook-f"></i></a>
+                <a href="#" aria-label="인스타그램"><i class="fab fa-instagram"></i></a>
+                <a href="#" aria-label="유튜브"><i class="fab fa-youtube"></i></a>
+              </div>
+            </div>
+            <div>
+              <h4>바로가기</h4>
+              <ul>
+                <li><a href="admissions.html" class="active">입학안내</a></li>
+                <li><a href="departments.html">학과·전공</a></li>
+                <li><a href="campus-life.html">캠퍼스라이프</a></li>
+              </ul>
+            </div>
+            <div>
+              <h4>학사 정보</h4>
+              <ul>
+                <li><a href="#">학사일정</a></li>
+                <li><a href="#">장학·복지</a></li>
+                <li><a href="#">국제교류</a></li>
+                <li><a href="#">취·창업 지원</a></li>
+              </ul>
+            </div>
+            <div>
+              <h4>고객 지원</h4>
+              <ul>
+                <li><a href="news-events.html">공지사항</a></li>
+                <li><a href="#">증명서 발급</a></li>
+                <li><a href="contact-us.html">문의하기</a></li>
+                <li><a href="#">개인정보처리방침</a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="footer-bottom">
+            ⓒ 2024 Incheon Science College. All rights reserved.
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <script>
+      const navToggle = document.getElementById('navToggle');
+      const primaryNav = document.getElementById('primaryNav');
+
+      navToggle.addEventListener('click', () => {
+        const isOpen = navToggle.classList.toggle('active');
+        primaryNav.classList.toggle('open', isOpen);
+        navToggle.setAttribute('aria-expanded', isOpen);
+      });
+    </script>
+  </body>
+</html>

--- a/assets/css/custom-style.css
+++ b/assets/css/custom-style.css
@@ -125,6 +125,10 @@ img {
   transform: scaleX(1);
 }
 
+.primary-nav a.active::after {
+  transform: scaleX(1);
+}
+
 .nav-actions {
   display: flex;
   gap: 0.75rem;
@@ -312,6 +316,21 @@ img {
   top: -60px;
   right: -60px;
   z-index: 1;
+}
+
+.hero--sub {
+  padding: 3.2rem 0 3.6rem;
+  background: radial-gradient(circle at 10% 10%, rgba(74, 167, 255, 0.08) 0, rgba(74, 167, 255, 0) 55%),
+    #ffffff;
+}
+
+.hero--sub .hero-inner {
+  grid-template-columns: minmax(0, 1fr);
+  text-align: left;
+}
+
+.hero--sub .hero-copy {
+  max-width: 720px;
 }
 
 .quick-links {
@@ -519,6 +538,51 @@ img {
   line-height: 1.6;
 }
 
+.program-card ul {
+  margin: 1rem 0 0;
+  padding-left: 1.2rem;
+  color: var(--color-muted);
+  line-height: 1.6;
+}
+
+.program-card ul li + li {
+  margin-top: 0.35rem;
+}
+
+.timeline {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline-item {
+  background: #ffffff;
+  border-radius: 22px;
+  padding: 1.6rem 1.8rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.timeline-item h3 {
+  margin: 0 0 0.6rem;
+  font-size: 1.4rem;
+  color: var(--color-navy);
+}
+
+.timeline-item p {
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.6;
+}
+
+.event-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.event-grid .event-card {
+  height: 100%;
+}
+
 .cta {
   position: relative;
   background: linear-gradient(135deg, rgba(8, 59, 114, 0.95), rgba(0, 166, 158, 0.85));
@@ -628,7 +692,8 @@ img {
 
   .quick-card-grid,
   .program-grid,
-  .stats-grid {
+  .stats-grid,
+  .event-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -674,7 +739,8 @@ img {
 
   .quick-card-grid,
   .program-grid,
-  .stats-grid {
+  .stats-grid,
+  .event-grid {
     grid-template-columns: 1fr;
   }
 

--- a/campus-life.html
+++ b/campus-life.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>캠퍼스라이프 | 영지국제대학교</title>
+    <meta
+      name="description"
+      content="영지국제대학교의 학생 지원, 동아리, 글로벌 교류, 생활 인프라를 소개합니다."
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700;900&display=swap"
+      rel="stylesheet"
+    />
+    <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/fontawesome.css" />
+    <link rel="stylesheet" href="assets/css/custom-style.css" />
+  </head>
+  <body>
+    <div class="page-wrapper">
+      <header class="site-header">
+        <div class="top-bar">
+          <div class="container">
+            <span>입학상담 032-123-4567</span>
+            <span>대표이메일 admissions@GTCC.ac.kr</span>
+            <div class="d-none d-md-flex gap-3">
+              <a href="#">재학생 포털</a>
+              <a href="#">원격수업지원센터</a>
+              <a href="#">글로벌캠퍼스</a>
+            </div>
+          </div>
+        </div>
+        <div class="container nav-wrapper">
+          <a class="brand" href="index.html">
+            <img src="assets/images/gtcc-logo-trans.png" alt="영지국제대학교 로고" />
+            영지국제대학교
+          </a>
+          <nav class="primary-nav" id="primaryNav">
+            <a href="about.html">대학소개</a>
+            <a href="news-events.html">소식·행사</a>
+            <a href="departments.html">학과안내</a>
+            <a href="admissions.html">입학안내</a>
+            <a href="campus-life.html" class="active" aria-current="page">캠퍼스라이프</a>
+          </nav>
+          <div class="nav-actions">
+            <a class="btn-pill outline" href="campus-life.html">캠퍼스맵</a>
+            <a class="btn-pill primary" href="admissions.html">입학원서</a>
+          </div>
+          <button class="nav-toggle" id="navToggle" aria-label="메뉴 열기">
+            <span></span>
+          </button>
+        </div>
+      </header>
+
+      <main>
+        <section class="hero hero--sub">
+          <div class="container hero-inner">
+            <div class="hero-copy">
+              <span class="eyebrow">Campus Life</span>
+              <h1>함께 성장하는 다채로운 대학생활</h1>
+              <p>
+                스마트 러닝 인프라부터 글로벌 교류, 지역사회 연계 프로그램까지, 영지국제대학교의 특별한 캠퍼스 경험을 소개합니다.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="quick-links">
+          <div class="container">
+            <div class="section-header">
+              <span>Learning Space</span>
+              <h2>스마트 캠퍼스 인프라</h2>
+              <p>디지털 학습 환경과 창의 공간이 결합된 미래형 캠퍼스를 체험하세요.</p>
+            </div>
+            <div class="quick-card-grid">
+              <article class="quick-card">
+                <i class="fas fa-network-wired" aria-hidden="true"></i>
+                <h3>스마트 러닝 허브</h3>
+                <p>24시간 개방형 학습공간과 온라인 스튜디오를 통해 유연한 학습 경험을 제공합니다.</p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-vials" aria-hidden="true"></i>
+                <h3>융합 실습관</h3>
+                <p>AI, 바이오, XR 실습실을 갖춘 통합 연구 공간에서 현장형 프로젝트를 수행합니다.</p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-tree" aria-hidden="true"></i>
+                <h3>에코 캠퍼스</h3>
+                <p>탄소중립 스마트팜, 태양광 쉼터 등 친환경 시설을 통해 지속가능한 캠퍼스를 실현합니다.</p>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section class="programs">
+          <div class="container">
+            <div class="section-header">
+              <span>Student Life</span>
+              <h2>학생활동 &amp; 동아리</h2>
+              <p>관심사별 동아리와 학생자치활동이 활발히 운영되고 있습니다.</p>
+            </div>
+            <div class="program-grid">
+              <article class="program-card">
+                <div class="content">
+                  <h3>창업 동아리 NEST</h3>
+                  <p>스타트업 아이디어 발굴, 멘토링, 데모데이를 통해 창업 역량을 강화합니다.</p>
+                </div>
+              </article>
+              <article class="program-card">
+                <div class="content">
+                  <h3>글로벌 버디</h3>
+                  <p>교환학생과 재학생이 팀을 이루어 문화 교류 활동과 지역 탐방 프로그램을 진행합니다.</p>
+                </div>
+              </article>
+              <article class="program-card">
+                <div class="content">
+                  <h3>GTCC 메이커스</h3>
+                  <p>메이커 스페이스에서 하드웨어 제작, 3D 프린팅, 공모전 참가를 지원합니다.</p>
+                </div>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section class="quick-links">
+          <div class="container">
+            <div class="section-header">
+              <span>Support Programs</span>
+              <h2>학생지원 서비스</h2>
+              <p>학업, 진로, 생활 전반을 위한 맞춤형 프로그램을 운영합니다.</p>
+            </div>
+            <div class="quick-card-grid">
+              <article class="quick-card">
+                <i class="fas fa-heartbeat" aria-hidden="true"></i>
+                <h3>웰니스 센터</h3>
+                <p>상담, 심리치유, 피트니스 프로그램으로 건강한 캠퍼스 생활을 돕습니다.</p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-briefcase" aria-hidden="true"></i>
+                <h3>커리어 라운지</h3>
+                <p>취업 컨설팅, 현직자 멘토링, 기업 매칭 프로그램을 제공합니다.</p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-plane-departure" aria-hidden="true"></i>
+                <h3>글로벌 익스피리언스</h3>
+                <p>해외 단기연수, 국제 자원봉사, 글로벌 인턴십으로 세계를 경험하세요.</p>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section class="cta">
+          <div class="container">
+            <h2>캠퍼스 투어 신청</h2>
+            <p>재학생 도슨트와 함께하는 캠퍼스 투어에 참여하고 생생한 대학생활을 체험해 보세요.</p>
+            <a class="btn-pill primary" href="contact-us.html">투어 예약</a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="container">
+          <div class="footer-grid">
+            <div>
+              <h4>영지국제대학교</h4>
+              <p>
+                21987 인천광역시 연수구 미래로 123<br />
+                TEL 032-123-4567 · FAX 032-987-6543<br />
+                E-mail admissions@GTCC.ac.kr
+              </p>
+              <div class="social">
+                <a href="#" aria-label="페이스북"><i class="fab fa-facebook-f"></i></a>
+                <a href="#" aria-label="인스타그램"><i class="fab fa-instagram"></i></a>
+                <a href="#" aria-label="유튜브"><i class="fab fa-youtube"></i></a>
+              </div>
+            </div>
+            <div>
+              <h4>바로가기</h4>
+              <ul>
+                <li><a href="admissions.html">입학안내</a></li>
+                <li><a href="departments.html">학과·전공</a></li>
+                <li><a href="campus-life.html" class="active">캠퍼스라이프</a></li>
+              </ul>
+            </div>
+            <div>
+              <h4>학사 정보</h4>
+              <ul>
+                <li><a href="#">학사일정</a></li>
+                <li><a href="#">장학·복지</a></li>
+                <li><a href="#">국제교류</a></li>
+                <li><a href="#">취·창업 지원</a></li>
+              </ul>
+            </div>
+            <div>
+              <h4>고객 지원</h4>
+              <ul>
+                <li><a href="news-events.html">공지사항</a></li>
+                <li><a href="#">증명서 발급</a></li>
+                <li><a href="contact-us.html">문의하기</a></li>
+                <li><a href="#">개인정보처리방침</a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="footer-bottom">
+            ⓒ 2024 Incheon Science College. All rights reserved.
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <script>
+      const navToggle = document.getElementById('navToggle');
+      const primaryNav = document.getElementById('primaryNav');
+
+      navToggle.addEventListener('click', () => {
+        const isOpen = navToggle.classList.toggle('active');
+        primaryNav.classList.toggle('open', isOpen);
+        navToggle.setAttribute('aria-expanded', isOpen);
+      });
+    </script>
+  </body>
+</html>

--- a/departments.html
+++ b/departments.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>학과안내 | 영지국제대학교</title>
+    <meta
+      name="description"
+      content="영지국제대학교의 특성화 학과와 융합전공, 교육과정, 진로를 소개합니다."
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700;900&display=swap"
+      rel="stylesheet"
+    />
+    <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/fontawesome.css" />
+    <link rel="stylesheet" href="assets/css/custom-style.css" />
+  </head>
+  <body>
+    <div class="page-wrapper">
+      <header class="site-header">
+        <div class="top-bar">
+          <div class="container">
+            <span>입학상담 032-123-4567</span>
+            <span>대표이메일 admissions@GTCC.ac.kr</span>
+            <div class="d-none d-md-flex gap-3">
+              <a href="#">재학생 포털</a>
+              <a href="#">원격수업지원센터</a>
+              <a href="#">글로벌캠퍼스</a>
+            </div>
+          </div>
+        </div>
+        <div class="container nav-wrapper">
+          <a class="brand" href="index.html">
+            <img src="assets/images/gtcc-logo-trans.png" alt="영지국제대학교 로고" />
+            영지국제대학교
+          </a>
+          <nav class="primary-nav" id="primaryNav">
+            <a href="about.html">대학소개</a>
+            <a href="news-events.html">소식·행사</a>
+            <a href="departments.html" class="active" aria-current="page">학과안내</a>
+            <a href="admissions.html">입학안내</a>
+            <a href="campus-life.html">캠퍼스라이프</a>
+          </nav>
+          <div class="nav-actions">
+            <a class="btn-pill outline" href="campus-life.html">캠퍼스맵</a>
+            <a class="btn-pill primary" href="admissions.html">입학원서</a>
+          </div>
+          <button class="nav-toggle" id="navToggle" aria-label="메뉴 열기">
+            <span></span>
+          </button>
+        </div>
+      </header>
+
+      <main>
+        <section class="hero hero--sub">
+          <div class="container hero-inner">
+            <div class="hero-copy">
+              <span class="eyebrow">Academic Programs</span>
+              <h1>4차 산업혁명을 선도하는 융합 교육</h1>
+              <p>
+                산업 현장과 연결된 실무 중심 커리큘럼으로 미래를 준비하세요. 모든 학과에서 프로젝트 기반 학습과 맞춤형 진로 지원을 제공합니다.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="programs">
+          <div class="container">
+            <div class="section-header">
+              <span>Schools &amp; Divisions</span>
+              <h2>주요 학부/학과</h2>
+              <p>GTCC만의 특화된 교육과정을 통해 실전 역량을 키울 수 있습니다.</p>
+            </div>
+            <div class="program-grid">
+              <article class="program-card">
+                <img src="assets/images/courses-01.jpg" alt="AI 융합학부 실습" />
+                <div class="content">
+                  <h3>AI 융합학부</h3>
+                  <p>
+                    인공지능, 빅데이터, 로봇 제어를 통합한 커리큘럼과 산학 연계 캡스톤 디자인을 통해 차세대 디지털 산업 전문가를 양성합니다.
+                  </p>
+                  <ul>
+                    <li>트랙: AI엔지니어링, 데이터사이언스, 로보틱스</li>
+                    <li>주요 진출: 스마트 제조, 자율주행, 금융 데이터 분석</li>
+                  </ul>
+                </div>
+              </article>
+              <article class="program-card">
+                <img src="assets/images/courses-02.jpg" alt="바이오헬스케어 실험실" />
+                <div class="content">
+                  <h3>바이오헬스케어학과</h3>
+                  <p>
+                    바이오 분석 기술과 디지털 헬스 솔루션을 융합하여 헬스케어 혁신을 선도할 현장형 전문가를 육성합니다.
+                  </p>
+                  <ul>
+                    <li>트랙: 바이오분석, 디지털헬스, 제약품질</li>
+                    <li>주요 진출: 의료 연구소, 제약/바이오 기업, 헬스케어 스타트업</li>
+                  </ul>
+                </div>
+              </article>
+              <article class="program-card">
+                <img src="assets/images/courses-03.jpg" alt="스마트관광 콘텐츠 제작" />
+                <div class="content">
+                  <h3>스마트관광콘텐츠학과</h3>
+                  <p>
+                    XR, 메타버스 기술 기반의 관광콘텐츠 제작과 데이터 분석을 통해 글로벌 관광 산업을 이끌 인재를 양성합니다.
+                  </p>
+                  <ul>
+                    <li>트랙: XR콘텐츠, 관광데이터, 지역브랜딩</li>
+                    <li>주요 진출: 관광공기업, 콘텐츠 제작사, 도시브랜딩 기관</li>
+                  </ul>
+                </div>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section class="quick-links">
+          <div class="container">
+            <div class="section-header">
+              <span>Special Programs</span>
+              <h2>융합전공 &amp; 비교과</h2>
+              <p>학문 간 경계를 허무는 협업 프로젝트와 글로벌 교육 기회를 제공합니다.</p>
+            </div>
+            <div class="quick-card-grid">
+              <article class="quick-card">
+                <i class="fas fa-vr-cardboard" aria-hidden="true"></i>
+                <h3>디지털트윈 융합전공</h3>
+                <p>AI, 기계, 디자인 학생이 협업하여 스마트팩토리 디지털트윈을 개발합니다.</p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-seedling" aria-hidden="true"></i>
+                <h3>지속가능 도시혁신 비교과</h3>
+                <p>지역 문제 해결을 위한 서비스디자인 워크숍과 국제 교류 프로젝트로 구성됩니다.</p>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-user-graduate" aria-hidden="true"></i>
+                <h3>산학연계 마이크로디그리</h3>
+                <p>기업 현장 전문가가 참여하는 단기 집중 과정으로 취업 경쟁력을 높입니다.</p>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section class="programs">
+          <div class="container">
+            <div class="section-header">
+              <span>Support</span>
+              <h2>학습 지원 서비스</h2>
+              <p>입학부터 졸업 이후까지 이어지는 전주기적 성장 지원을 제공합니다.</p>
+            </div>
+            <div class="program-grid">
+              <article class="program-card">
+                <div class="content">
+                  <h3>러닝 이노베이션 센터</h3>
+                  <p>AI 튜터링, 학습 코칭, MOOC 연계 등 맞춤형 학습 지원을 운영합니다.</p>
+                </div>
+              </article>
+              <article class="program-card">
+                <div class="content">
+                  <h3>커리어 디자인 허브</h3>
+                  <p>전문 컨설턴트와 함께하는 진로 설계, 취업 역량 강화 세미나를 제공합니다.</p>
+                </div>
+              </article>
+              <article class="program-card">
+                <div class="content">
+                  <h3>글로벌 브릿지</h3>
+                  <p>복수학위, 해외 인턴십, 글로벌 캡스톤 프로그램을 통해 국제 경쟁력을 키웁니다.</p>
+                </div>
+              </article>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="container">
+          <div class="footer-grid">
+            <div>
+              <h4>영지국제대학교</h4>
+              <p>
+                21987 인천광역시 연수구 미래로 123<br />
+                TEL 032-123-4567 · FAX 032-987-6543<br />
+                E-mail admissions@GTCC.ac.kr
+              </p>
+              <div class="social">
+                <a href="#" aria-label="페이스북"><i class="fab fa-facebook-f"></i></a>
+                <a href="#" aria-label="인스타그램"><i class="fab fa-instagram"></i></a>
+                <a href="#" aria-label="유튜브"><i class="fab fa-youtube"></i></a>
+              </div>
+            </div>
+            <div>
+              <h4>바로가기</h4>
+              <ul>
+                <li><a href="admissions.html">입학안내</a></li>
+                <li><a href="departments.html" class="active">학과·전공</a></li>
+                <li><a href="campus-life.html">캠퍼스라이프</a></li>
+              </ul>
+            </div>
+            <div>
+              <h4>학사 정보</h4>
+              <ul>
+                <li><a href="#">학사일정</a></li>
+                <li><a href="#">장학·복지</a></li>
+                <li><a href="#">국제교류</a></li>
+                <li><a href="#">취·창업 지원</a></li>
+              </ul>
+            </div>
+            <div>
+              <h4>고객 지원</h4>
+              <ul>
+                <li><a href="news-events.html">공지사항</a></li>
+                <li><a href="#">증명서 발급</a></li>
+                <li><a href="contact-us.html">문의하기</a></li>
+                <li><a href="#">개인정보처리방침</a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="footer-bottom">
+            ⓒ 2024 Incheon Science College. All rights reserved.
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <script>
+      const navToggle = document.getElementById('navToggle');
+      const primaryNav = document.getElementById('primaryNav');
+
+      navToggle.addEventListener('click', () => {
+        const isOpen = navToggle.classList.toggle('active');
+        primaryNav.classList.toggle('open', isOpen);
+        navToggle.setAttribute('aria-expanded', isOpen);
+      });
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -36,15 +36,15 @@
             영지국제대학교
           </a>
           <nav class="primary-nav" id="primaryNav">
-            <a href="#about">대학소개</a>
-            <a href="#programs">학과안내</a>
-            <a href="#admission">입학안내</a>
-            <a href="#news">소식·행사</a>
-            <a href="#campus">캠퍼스라이프</a>
+            <a href="about.html">대학소개</a>
+            <a href="news-events.html">소식·행사</a>
+            <a href="departments.html">학과안내</a>
+            <a href="admissions.html">입학안내</a>
+            <a href="campus-life.html">캠퍼스라이프</a>
           </nav>
           <div class="nav-actions">
-            <a class="btn-pill outline" href="#">캠퍼스맵</a>
-            <a class="btn-pill primary" href="#admission">입학원서</a>
+            <a class="btn-pill outline" href="campus-life.html">캠퍼스맵</a>
+            <a class="btn-pill primary" href="admissions.html">입학원서</a>
           </div>
           <button class="nav-toggle" id="navToggle" aria-label="메뉴 열기">
             <span></span>
@@ -64,8 +64,8 @@
                 함께 성장하는 미래지향적 교육 환경을 만나보세요.
               </p>
               <div class="hero-cta">
-                <a class="btn-pill primary" href="#admission">2025학년도 입학안내</a>
-                <a class="btn-pill outline" href="#campus">캠퍼스 투어</a>
+                <a class="btn-pill primary" href="admissions.html">2025학년도 입학안내</a>
+                <a class="btn-pill outline" href="campus-life.html">캠퍼스 투어</a>
               </div>
               <div class="hero-meta">
                 <span>#스마트융합대학</span>
@@ -103,7 +103,7 @@
                   계열별 전형 정보, 모집 일정, 장학 혜택 등 2025학년도 신입생 모집에
                   필요한 모든 정보를 확인하세요.
                 </p>
-                <a class="arrow" href="#admission">자세히 보기 →</a>
+                <a class="arrow" href="admissions.html">자세히 보기 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-flask" aria-hidden="true"></i>
@@ -112,7 +112,7 @@
                   메타버스 콘텐츠 제작실, 바이오·헬스케어 연구실 등 최신 장비를 갖춘
                   실습실에서 현장 중심 역량을 키웁니다.
                 </p>
-                <a class="arrow" href="#programs">실습 환경 보기 →</a>
+                <a class="arrow" href="departments.html">실습 환경 보기 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-hands-helping" aria-hidden="true"></i>
@@ -121,7 +121,7 @@
                   학습 코칭, 진로 컨설팅, 글로벌 교류 프로그램 등 학생의 성장을 돕는
                   다양한 서비스를 제공합니다.
                 </p>
-                <a class="arrow" href="#campus">지원 프로그램 →</a>
+                <a class="arrow" href="campus-life.html">지원 프로그램 →</a>
               </article>
             </div>
           </div>
@@ -276,7 +276,7 @@
                 <p>
                   24시간 개방형 학습공간과 온라인 스튜디오를 통해 유연한 학습 경험을 제공합니다.
                 </p>
-                <a class="arrow" href="#">학습공간 안내 →</a>
+                <a class="arrow" href="campus-life.html">학습공간 안내 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-globe-asia" aria-hidden="true"></i>
@@ -284,7 +284,7 @@
                 <p>
                   해외 자매대학과의 공동 프로젝트, 단기 연수, 글로벌 인턴십 기회를 제공합니다.
                 </p>
-                <a class="arrow" href="#">교환학생 안내 →</a>
+                <a class="arrow" href="campus-life.html">교환학생 안내 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-leaf" aria-hidden="true"></i>
@@ -292,7 +292,7 @@
                 <p>
                   지역 기업 협력 프로젝트와 봉사 프로그램을 통해 지속가능한 성장에 기여합니다.
                 </p>
-                <a class="arrow" href="#">지역연계 프로그램 →</a>
+                <a class="arrow" href="campus-life.html">지역연계 프로그램 →</a>
               </article>
             </div>
           </div>
@@ -306,7 +306,7 @@
               기반으로, 졸업 이후까지 이어지는 커리어 지원을 제공합니다. 지금 바로 상담을 신청해
               더 큰 가능성을 확인해 보세요.
             </p>
-            <a class="btn-pill primary" href="#admission">입학상담 신청</a>
+            <a class="btn-pill primary" href="admissions.html">입학상담 신청</a>
           </section>
         </div>
       </main>
@@ -330,9 +330,9 @@
             <div>
               <h4>바로가기</h4>
               <ul>
-                <li><a href="#admission">입학안내</a></li>
-                <li><a href="#programs">학과·전공</a></li>
-                <li><a href="#campus">캠퍼스라이프</a></li>
+                <li><a href="admissions.html">입학안내</a></li>
+                <li><a href="departments.html">학과·전공</a></li>
+                <li><a href="campus-life.html">캠퍼스라이프</a></li>
                 <li><a href="#">대학기관</a></li>
               </ul>
             </div>
@@ -348,7 +348,7 @@
             <div>
               <h4>고객 지원</h4>
               <ul>
-                <li><a href="#">공지사항</a></li>
+                <li><a href="news-events.html">공지사항</a></li>
                 <li><a href="#">증명서 발급</a></li>
                 <li><a href="contact-us.html">문의하기</a></li>
                 <li><a href="#">개인정보처리방침</a></li>

--- a/news-events.html
+++ b/news-events.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>소식·행사 | 영지국제대학교</title>
+    <meta
+      name="description"
+      content="영지국제대학교의 최신 뉴스, 공지사항, 캠퍼스 행사 일정을 확인하세요."
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700;900&display=swap"
+      rel="stylesheet"
+    />
+    <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/fontawesome.css" />
+    <link rel="stylesheet" href="assets/css/custom-style.css" />
+  </head>
+  <body>
+    <div class="page-wrapper">
+      <header class="site-header">
+        <div class="top-bar">
+          <div class="container">
+            <span>입학상담 032-123-4567</span>
+            <span>대표이메일 admissions@GTCC.ac.kr</span>
+            <div class="d-none d-md-flex gap-3">
+              <a href="#">재학생 포털</a>
+              <a href="#">원격수업지원센터</a>
+              <a href="#">글로벌캠퍼스</a>
+            </div>
+          </div>
+        </div>
+        <div class="container nav-wrapper">
+          <a class="brand" href="index.html">
+            <img src="assets/images/gtcc-logo-trans.png" alt="영지국제대학교 로고" />
+            영지국제대학교
+          </a>
+          <nav class="primary-nav" id="primaryNav">
+            <a href="about.html">대학소개</a>
+            <a href="news-events.html" class="active" aria-current="page">소식·행사</a>
+            <a href="departments.html">학과안내</a>
+            <a href="admissions.html">입학안내</a>
+            <a href="campus-life.html">캠퍼스라이프</a>
+          </nav>
+          <div class="nav-actions">
+            <a class="btn-pill outline" href="campus-life.html">캠퍼스맵</a>
+            <a class="btn-pill primary" href="admissions.html">입학원서</a>
+          </div>
+          <button class="nav-toggle" id="navToggle" aria-label="메뉴 열기">
+            <span></span>
+          </button>
+        </div>
+      </header>
+
+      <main>
+        <section class="hero hero--sub">
+          <div class="container hero-inner">
+            <div class="hero-copy">
+              <span class="eyebrow">News &amp; Events</span>
+              <h1>GTCC의 최신 소식을 만나보세요</h1>
+              <p>
+                대학의 공지사항, 언론보도, 연구 성과와 다채로운 캠퍼스 행사를 한 곳에서 확인할 수 있습니다.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="news-events">
+          <div class="container">
+            <div class="section-header">
+              <span>Newsroom</span>
+              <h2>주요 뉴스</h2>
+              <p>미래 교육을 향한 GTCC의 다양한 활동을 소개합니다.</p>
+            </div>
+            <div class="news-layout">
+              <div>
+                <article class="news-card">
+                  <time datetime="2024-07-02">2024.07.02</time>
+                  <h3>스마트팩토리 혁신센터 개소</h3>
+                  <p>
+                    지역 제조기업과 연계한 실증형 교육 공간이 문을 열었습니다. AI 기반 공정 제어, 디지털 트윈 실습 등 최첨단 프로그램을 제공합니다.
+                  </p>
+                </article>
+                <article class="news-card">
+                  <time datetime="2024-06-28">2024.06.28</time>
+                  <h3>2025학년도 수시 모집요강 발표</h3>
+                  <p>
+                    신산업 융합학부 신설과 함께 장학 프로그램이 확대되었습니다. 모집 단위별 세부 전형을 확인하세요.
+                  </p>
+                </article>
+                <article class="news-card">
+                  <time datetime="2024-06-18">2024.06.18</time>
+                  <h3>학생 창업동아리 IR 데모데이</h3>
+                  <p>
+                    12개 창업팀이 미래 모빌리티, 바이오 헬스, XR 콘텐츠 분야의 혁신 아이디어를 선보였습니다.
+                  </p>
+                </article>
+              </div>
+              <div>
+                <article class="news-card">
+                  <time datetime="2024-05-30">2024.05.30</time>
+                  <h3>GTCC-글로벌테크 MOU 체결</h3>
+                  <p>
+                    공동 연구와 해외 인턴십을 위한 전략적 파트너십을 체결하고 학생들의 글로벌 진출을 지원합니다.
+                  </p>
+                </article>
+                <article class="news-card">
+                  <time datetime="2024-05-12">2024.05.12</time>
+                  <h3>지역사회 연계 봉사주간</h3>
+                  <p>
+                    재학생과 교직원이 함께 환경 정화, 디지털 교육 봉사 등 다양한 사회공헌 활동을 진행했습니다.
+                  </p>
+                </article>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="programs">
+          <div class="container">
+            <div class="section-header">
+              <span>Event Calendar</span>
+              <h2>다가오는 행사</h2>
+              <p>학생과 지역사회가 함께 즐기는 다양한 이벤트를 확인하세요.</p>
+            </div>
+            <div class="event-grid">
+              <article class="event-card">
+                <time datetime="2024-07-15">7.15 (월) 14:00</time>
+                <h4>미래에너지공학과 오픈랩 투어</h4>
+                <p>탄소중립 에너지 실험실 탐방과 교수진 Q&amp;A 세션이 진행됩니다.</p>
+              </article>
+              <article class="event-card">
+                <time datetime="2024-07-22">7.22 (월) 10:00</time>
+                <h4>입학설명회 &amp; 1:1 상담</h4>
+                <p>학과별 상담과 재학생 멘토링을 통한 맞춤 입학 준비를 지원합니다.</p>
+              </article>
+              <article class="event-card">
+                <time datetime="2024-07-27">7.27 (토) 11:00</time>
+                <h4>글로벌 문화 페스티벌</h4>
+                <p>세계 문화 체험 부스, 다국적 푸드트럭, 라이브 공연이 마련됩니다.</p>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section class="quick-links">
+          <div class="container">
+            <div class="section-header">
+              <span>Media Kit</span>
+              <h2>보도자료 &amp; 문의</h2>
+              <p>언론 및 외부 기관에서 사용할 수 있는 자료와 연락처를 안내합니다.</p>
+            </div>
+            <div class="quick-card-grid">
+              <article class="quick-card">
+                <i class="fas fa-file-download" aria-hidden="true"></i>
+                <h3>보도자료 다운로드</h3>
+                <p>대학 소개자료, 주요 성과 리포트, 이미지 에셋을 제공합니다.</p>
+                <a class="arrow" href="#">자료실 바로가기 →</a>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-bullhorn" aria-hidden="true"></i>
+                <h3>공지사항 구독</h3>
+                <p>뉴스레터를 신청하면 대학 소식을 이메일로 받아볼 수 있습니다.</p>
+                <a class="arrow" href="#">신청하기 →</a>
+              </article>
+              <article class="quick-card">
+                <i class="fas fa-envelope-open-text" aria-hidden="true"></i>
+                <h3>미디어 문의</h3>
+                <p>홍보팀 press@gtcc.ac.kr<br />032-555-1234</p>
+                <a class="arrow" href="contact-us.html">문의하기 →</a>
+              </article>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="container">
+          <div class="footer-grid">
+            <div>
+              <h4>영지국제대학교</h4>
+              <p>
+                21987 인천광역시 연수구 미래로 123<br />
+                TEL 032-123-4567 · FAX 032-987-6543<br />
+                E-mail admissions@GTCC.ac.kr
+              </p>
+              <div class="social">
+                <a href="#" aria-label="페이스북"><i class="fab fa-facebook-f"></i></a>
+                <a href="#" aria-label="인스타그램"><i class="fab fa-instagram"></i></a>
+                <a href="#" aria-label="유튜브"><i class="fab fa-youtube"></i></a>
+              </div>
+            </div>
+            <div>
+              <h4>바로가기</h4>
+              <ul>
+                <li><a href="admissions.html">입학안내</a></li>
+                <li><a href="departments.html">학과·전공</a></li>
+                <li><a href="campus-life.html">캠퍼스라이프</a></li>
+              </ul>
+            </div>
+            <div>
+              <h4>학사 정보</h4>
+              <ul>
+                <li><a href="#">학사일정</a></li>
+                <li><a href="#">장학·복지</a></li>
+                <li><a href="#">국제교류</a></li>
+                <li><a href="#">취·창업 지원</a></li>
+              </ul>
+            </div>
+            <div>
+              <h4>고객 지원</h4>
+              <ul>
+                <li><a href="news-events.html" class="active">공지사항</a></li>
+                <li><a href="#">증명서 발급</a></li>
+                <li><a href="contact-us.html">문의하기</a></li>
+                <li><a href="#">개인정보처리방침</a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="footer-bottom">
+            ⓒ 2024 Incheon Science College. All rights reserved.
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <script>
+      const navToggle = document.getElementById('navToggle');
+      const primaryNav = document.getElementById('primaryNav');
+
+      navToggle.addEventListener('click', () => {
+        const isOpen = navToggle.classList.toggle('active');
+        primaryNav.classList.toggle('open', isOpen);
+        navToggle.setAttribute('aria-expanded', isOpen);
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- reorder the main navigation to match the requested 탭 sequence and point to dedicated pages
- add standalone pages for 대학소개, 소식·행사, 학과안내, 입학안내, 캠퍼스라이프 with tailored content and shared layout
- extend the shared stylesheet to style the new layouts including hero variants, timelines, and event grids

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dcf1916ff08332a0e673a9ab7a8926