### PR TITLE
Remove quick card arrow links

### DIFF
--- a/global-campus.html
+++ b/global-campus.html
@@ -88,7 +88,6 @@
                   북미·유럽·아시아 35개 협약 대학과의 교환학생 프로그램으로 국제 감각을
                   키워보세요.
                 </p>
-                <a class="arrow" href="#">선발 일정 보기 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-university" aria-hidden="true"></i>
@@ -97,7 +96,6 @@
                   캐나다, 싱가포르 대학과의 복수학위 과정을 통해 글로벌 커리어를 설계할 수
                   있습니다.
                 </p>
-                <a class="arrow" href="#">파트너 대학 안내 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-briefcase" aria-hidden="true"></i>
@@ -105,7 +103,6 @@
                 <p>
                   해외 기업 및 국제기구 인턴십과 현장실습으로 실무 역량과 네트워크를 확장하세요.
                 </p>
-                <a class="arrow" href="#">모집 공고 확인 →</a>
               </article>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -103,7 +103,6 @@
                   계열별 전형 정보, 모집 일정, 장학 혜택 등 2025학년도 신입생 모집에
                   필요한 모든 정보를 확인하세요.
                 </p>
-                <a class="arrow" href="admissions.html">자세히 보기 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-flask" aria-hidden="true"></i>
@@ -112,7 +111,6 @@
                   메타버스 콘텐츠 제작실, 바이오·헬스케어 연구실 등 최신 장비를 갖춘
                   실습실에서 현장 중심 역량을 키웁니다.
                 </p>
-                <a class="arrow" href="departments.html">실습 환경 보기 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-hands-helping" aria-hidden="true"></i>
@@ -121,7 +119,6 @@
                   학습 코칭, 진로 컨설팅, 글로벌 교류 프로그램 등 학생의 성장을 돕는
                   다양한 서비스를 제공합니다.
                 </p>
-                <a class="arrow" href="campus-life.html">지원 프로그램 →</a>
               </article>
             </div>
           </div>
@@ -276,7 +273,6 @@
                 <p>
                   24시간 개방형 학습공간과 온라인 스튜디오를 통해 유연한 학습 경험을 제공합니다.
                 </p>
-                <a class="arrow" href="campus-life.html">학습공간 안내 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-globe-asia" aria-hidden="true"></i>
@@ -284,7 +280,6 @@
                 <p>
                   해외 자매대학과의 공동 프로젝트, 단기 연수, 글로벌 인턴십 기회를 제공합니다.
                 </p>
-                <a class="arrow" href="campus-life.html">교환학생 안내 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-leaf" aria-hidden="true"></i>
@@ -292,7 +287,6 @@
                 <p>
                   지역 기업 협력 프로젝트와 봉사 프로그램을 통해 지속가능한 성장에 기여합니다.
                 </p>
-                <a class="arrow" href="campus-life.html">지역연계 프로그램 →</a>
               </article>
             </div>
           </div>

--- a/news-events.html
+++ b/news-events.html
@@ -155,19 +155,16 @@
                 <i class="fas fa-file-download" aria-hidden="true"></i>
                 <h3>보도자료 다운로드</h3>
                 <p>대학 소개자료, 주요 성과 리포트, 이미지 에셋을 제공합니다.</p>
-                <a class="arrow" href="#">자료실 바로가기 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-bullhorn" aria-hidden="true"></i>
                 <h3>공지사항 구독</h3>
                 <p>뉴스레터를 신청하면 대학 소식을 이메일로 받아볼 수 있습니다.</p>
-                <a class="arrow" href="#">신청하기 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-envelope-open-text" aria-hidden="true"></i>
                 <h3>미디어 문의</h3>
                 <p>홍보팀 press@gtcc.ac.kr<br />032-555-1234</p>
-                <a class="arrow" href="contact-us.html">문의하기 →</a>
               </article>
             </div>
           </div>

--- a/student-portal.html
+++ b/student-portal.html
@@ -99,7 +99,6 @@
                 <p>
                   학사 공지, 강의 평가, 장학금 신청 등 월별 일정을 확인하고 놓치지 마세요.
                 </p>
-                <a class="arrow" href="news-events.html">일정 보기 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-laptop" aria-hidden="true"></i>
@@ -108,7 +107,6 @@
                   수강신청, 성적 조회, 온라인 강의실을 통합 제공하여 학습 진도를 체계적으로
                   관리합니다.
                 </p>
-                <a class="arrow" href="remote-learning-support.html">원격강의 바로가기 →</a>
               </article>
               <article class="quick-card">
                 <i class="fas fa-user-friends" aria-hidden="true"></i>
@@ -116,7 +114,6 @@
                 <p>
                   학습 코칭과 진로 상담, 취·창업 역량 강화를 위한 프로그램을 신청하세요.
                 </p>
-                <a class="arrow" href="campus-life.html">학생성장센터 안내 →</a>
               </article>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove the blue arrow call-to-action links from quick cards across the site

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dcf96be6908332b660d0f925bee6a3